### PR TITLE
rbld: make nixos-rebuild point to directory argument

### DIFF
--- a/rbld.nix
+++ b/rbld.nix
@@ -37,6 +37,7 @@ pkgs.writeShellApplication
     nixos-rebuild switch \
       --use-remote-sudo --fast \
       --log-format internal-json \
+      --flake "$directory" \
       |& nom --json || exit 1
 
     '';


### PR DESCRIPTION
Just `cd`ing into the proper directory isn't enough for nixos-rebuild to work, we need to pass the directory with `--flake`.