### PR TITLE
treewide: give all options both long and short forms

### DIFF
--- a/scripts/rbld.sh
+++ b/scripts/rbld.sh
@@ -3,17 +3,23 @@ shopt -s inherit_errexit
 directory="${RBLD_DIRECTORY:-/etc/nixos}" # Override default config directory value with $FLAKE
 
 # Or, if you just need to override the directory once, use `-d`
-while getopts ":d:" opt; do
-  case $opt in
-    d)
-      directory=$OPTARG
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+  shift
+
+  case "$opt" in
+    -d | --directory)
+      directory="$1"
+      shift
       ;;
-    \?) # Undefined option like -q
-      echo "Invalid option: -$OPTARG" >&2
+
+    -*)
+      echo "Invalid option \`$opt\`."
       exit 1
       ;;
-    :) # Setting -d without an argument
-      echo "Option -$OPTARG requires an argument." >&2
+
+    *)
+      echo "Argument \`$opt\` passed without an option."
       exit 1
       ;;
   esac

--- a/scripts/unify.sh
+++ b/scripts/unify.sh
@@ -8,26 +8,38 @@ FLAKE_COMMIT_MESSAGE="${UNIFY_COMMIT_MESSAGE:-flake: update flake.lock}"  # The 
 PRIMARY_BRANCHES="${UNIFY_PRIMARY_BRANCHES:-main master}"                 # branches that are allowed to have flake.lock changes commited to
 
 # Override default values without setting a permanent custom default via environment vars
-while getopts ":d:i:c:p:" opt; do
+while [[ $# -gt 0 ]]; do # Options for one-time overrides
+  opt="$1"
+  shift
+
   case $opt in
-    d)
-      DIRECTORY=$OPTARG
+    -d | --directory)
+      DIRECTORY=$1
+      shift
       ;;
-    i)
-      IMPORTANT_INPUTS=$OPTARG
+
+    -i | --inputs)
+      IMPORTANT_INPUTS=$1
+      shift
       ;;
-    c)
-      FLAKE_COMMIT_MESSAGE=$OPTARG
+
+    -c | --commit-message)
+      FLAKE_COMMIT_MESSAGE=$1
+      shift
       ;;
-    p)
-      PRIMARY_BRANCHES=$OPTARG
+
+    -p | --primary-branches)
+      PRIMARY_BRANCHES=$1
+      shift
       ;;
-    \?) # Undefined option like -q
-      echo "Invalid option: -$OPTARG" >&2
+
+    -*)
+      echo "Invalid option \`$opt\`."
       exit 1
       ;;
-    :) # using an argument without passing something (ex: `unify -d`)
-      echo "Option -$OPTARG requires an argument." >&2
+
+    *)
+      echo "Argument \`$opt\` passed without an option."
       exit 1
       ;;
   esac


### PR DESCRIPTION
Closes #17. 

Currently doesn't handle errors with a usage like this: `rbld -d`. However, a great start and will allow us to handle any type of option in the future, including stuff without arguments like `-h` and `-v`.