### PR TITLE
treewide: standardize environment variable format

### DIFF
--- a/scripts/rbld.sh
+++ b/scripts/rbld.sh
@@ -1,6 +1,6 @@
 shopt -s inherit_errexit
 
-directory="${FLAKE:-/etc/nixos}" # Override default config directory value with $FLAKE
+directory="${RBLD_DIRECTORY:-/etc/nixos}" # Override default config directory value with $FLAKE
 
 # Or, if you just need to override the directory once, use `-d`
 while getopts ":d:" opt; do

--- a/scripts/unify.sh
+++ b/scripts/unify.sh
@@ -1,10 +1,11 @@
 shopt -s inherit_errexit
 
 # Use environment variables if they're overriding the default values
-DIRECTORY="${FLAKE:-/etc/nixos}"                                               # Directory that your NixOS config is located in
-IMPORTANT_INPUTS="${INPUTS_TRIGGERING_REBUILD:-nixpkgs rebuild-but-less-dumb}" # Trigger `nix flake update` if one of these inputs is updated
-FLAKE_COMMIT_MESSAGE="${FLAKE_COMMIT_MESSAGE:-flake: update flake.lock}"       # The commit message to use for flake.lock updates
-PRIMARY_BRANCHES="${PRIMARY_BRANCHES:-main master}"                            # branches that are allowed to have flake.lock changes commited to
+
+DIRECTORY="${UNIFY_DIRECTORY:-/etc/nixos}"                                # Directory that your NixOS config is located in
+IMPORTANT_INPUTS="${UNIFY_TRACKED_INPUTS:-nixpkgs rebuild-but-less-dumb}" # Trigger `nix flake update` if one of these inputs is updated
+FLAKE_COMMIT_MESSAGE="${UNIFY_COMMIT_MESSAGE:-flake: update flake.lock}"  # The commit message to use for flake.lock updates
+PRIMARY_BRANCHES="${UNIFY_PRIMARY_BRANCHES:-main master}"                 # branches that are allowed to have flake.lock changes commited to
 
 # Override default values without setting a permanent custom default via environment vars
 while getopts ":d:i:c:p:" opt; do


### PR DESCRIPTION
Previously, I had named the environment variables based on whatever felt right in the moment. However, this led to many of the names being unclear to what the variable actually set. The messages also didn't clarify which program the environment variable was actually for, so if you set them, forgot about them, and saw them in your list of environment variables, you might have been confused.

Now, all the environment variables start with the name of the program ( RBLD or UNIFY). I also reworded some of the names slightly to be clearer.