### PR TITLE
fuiska: split into two scripts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,11 @@
           [
             rbld
             unify
-            hue # You don't need to install this manually, it's a dependency of the others. I just use install it manually for debugging
             fuiska
+
+            # Internal dependencies of the other commands, added to the devshell for debugging
+            hue
+            fight
           ];
         };
       }

--- a/packages/fight/fight.fish
+++ b/packages/fight/fight.fish
@@ -1,0 +1,44 @@
+#! /usr/bin/env fish
+# We store this in a separate script from Fuiska, since Fish can't parallelize functions
+
+set input $argv[1]
+set full_contents $argv[2]
+
+set data (echo $full_contents | jq -r --arg input $input '.nodes[$input]')
+
+if test -z "$data"
+    echo "No data found for input: $input"
+    exit 1
+end
+
+# The input will never update if it points to a specific commit hash
+set evergreen (echo $data | jq -r "if .original.rev then 0 else 1 end")
+
+if [ $evergreen = 0 ]
+    exit 0
+end
+
+set url (echo $data | jq -r '"https://" + .original.type + ".com/" + .locked.owner + "/" + .original.repo + ".git"')
+set branch (echo $data | jq -r 'if .original.ref then .original.ref else "" end')
+
+set oldHash (echo $data | jq -r ".locked.rev")
+
+if [ "$branch" = "" ]
+    set newHash (git ls-remote $url "HEAD" | cut -f1)
+else
+    set newHash (git ls-remote --branches $url $branch | cut -f1)
+
+    if [ "$newHash" = "" ] # What we assumed was a branch may have been a tag
+        set newHash (git ls-remote --tags $url $branch | cut -f1)
+    end
+
+end
+
+if [ "$newHash" = "" ]
+    echo "BAD, $input FAILED TO FETCH"
+    exit 1
+end
+
+if [ $oldHash != $newHash ]
+    echo $input
+end

--- a/packages/fight/package.nix
+++ b/packages/fight/package.nix
@@ -1,0 +1,13 @@
+{ pkgs, llakaLib, ... }:
+
+llakaLib.writeFishApplication
+{
+  name = "fight"; # Flake Input Gets Hash Tested
+  runtimeInputs = with pkgs;
+  [
+    git
+    jq
+  ];
+
+  text = builtins.readFile ./fight.fish;
+}

--- a/packages/fuiska/fuiska.fish
+++ b/packages/fuiska/fuiska.fish
@@ -27,58 +27,13 @@ cd $directory
 
 # We use "$()" to save as a multiline string
 set full_contents "$(cat flake.lock)"
-
-# Fish can't parallelize functions, so we hack around it by storing a
-# variable containing what would be in the function
-set check_script '
-set input $argv[1]
-set full_contents $argv[2]
-set data (echo $full_contents | jq -r --arg input "$input" \'.nodes[$input]\')
-
-if test -z "$data"
-    echo "No data found for input: $input"
-    exit 1
-end
-
-# The input will never update if it points to a specific commit hash
-set evergreen (echo $data | jq -r "if .original.rev then 0 else 1 end")
-
-if [ $evergreen = 0 ]
-    exit 0
-end
-
-set url (echo $data | jq -r "\"https://\" + .original.type + \".com/\" + .locked.owner + \"/\" + .original.repo + \".git\"")
-set branch (echo $data | jq -r "if .original.ref then .original.ref else \"\" end")
-
-set oldHash (echo $data | jq -r ".locked.rev")
-
-if [ "$branch" = "" ]
-    set newHash (git ls-remote $url "HEAD" | cut -f1)
-else
-    set newHash (git ls-remote --branches $url $branch | cut -f1)
-
-    if [ "$newHash" = "" ] # What we assumed was a branch may have been a tag
-        set newHash (git ls-remote --tags $url $branch | cut -f1)
-    end
-end
-
-if [ $newHash = "" ]
-    echo "BAD, $input FAILED TO FETCH"
-    exit 1
-end
-
-if [ $oldHash != $newHash ]
-    echo $input
-end
-'
-
 set inputs (echo $full_contents | jq -r ".nodes.root.inputs | keys[]")
 
 echo "Inputs that need updating:"
 
-# We parallelize via `fish -c` and `&`
+# We parallelize checking the input via `&`
 for input in $inputs
-    fish -c "$check_script" "$input" "$full_contents" &
+    fight $input $full_contents &
 end
 
 wait

--- a/packages/fuiska/package.nix
+++ b/packages/fuiska/package.nix
@@ -1,16 +1,16 @@
-{ pkgs, hue, llakaLib, ... }:
+{ pkgs, llakaLib, hue, fight, ... }:
 
 let
   nixpkgsDeps = with pkgs;
   [
     jq
     git
-    parallel
   ];
 
   selfDeps =
   [
     hue
+    fight
   ];
 
 in llakaLib.writeFishApplication


### PR DESCRIPTION
I previously committed this, thinking it was fine. However, nix doesn't add the other script to the built directory, for obvious reasons. We need to find a way to include another file in the result with `writeFishApplication`. This may require first adding this functionality in llakalib (I'm too tired for a markdown link right now).