### PR TITLE
fix: `git ls-remote` for ref `HEAD` in `fight`

### DIFF
--- a/packages/fight/fight.fish
+++ b/packages/fight/fight.fish
@@ -61,7 +61,7 @@ switch $host
 
 end
 
-if [ -z "$ref" ] # If we don't point to a specific tag or branch
+if [ -z "$ref" ] ; or [ "$ref" = "HEAD" ] # If we don't point to a specific tag or branch
     set newHash (git ls-remote $url "HEAD" | cut -f1)
 
 # Check both branches AND tags. We check for both the normal ref and the unpeeled ref.


### PR DESCRIPTION
[current version of `fight`](https://github.com/llakala/menu/blob/70a4fd2194ee2a4a50ff416d9c8c5ca6507d845e/packages/fight/fight.fish#L22-L88) fails with this flake input:
```json
"codeberg-cli": {
  "locked": {
    "lastModified": 1740504003,
    "narHash": "sha256-E8NaRDzBFV6fTY6gHTqWtc072ZjiT4o9L6vgTOJEx/g=",
    "rev": "888b2d23503e7dbb9323d40b6de0c3e6fa401292",
    "type": "tarball",
    "url": "https://codeberg.org/api/v1/repos/Aviac/codeberg-cli/archive/888b2d23503e7dbb9323d40b6de0c3e6fa401292.tar.gz"
  },
  "original": {
    "type": "tarball",
    "url": "https://codeberg.org/aviac/codeberg-cli/archive/HEAD.tar.gz"
  }
}
```
as the original input includes symref `HEAD`, `git ls-remote` is supplied with incorrect args `--branches` and `--tags`, which erroneously set `newHash` to empty string